### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/website/SmartState-frontend/js/chat.js
+++ b/website/SmartState-frontend/js/chat.js
@@ -119,6 +119,16 @@ function appendMessageImg(name, img, side, message_img) {
   msgerChat.scrollTop += 500;
 }
 
+// Escape HTML entities in user-provided text to prevent XSS
+function escapeHTML(str) {
+	return String(str)
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}
+
 function appendMessage(name, img, side, text, audio) {
 	//   Simple solution for small apps
 	let msgHTML = `
@@ -132,7 +142,7 @@ function appendMessage(name, img, side, text, audio) {
 		  </div>
   
 		  <div class="msg-text">
-		  ${text}<br>
+		  ${escapeHTML(text)}<br>
 		  </div>
 		</div>
 	  </div>
@@ -140,7 +150,7 @@ function appendMessage(name, img, side, text, audio) {
   
 	msgerChat.insertAdjacentHTML("beforeend", msgHTML);
 	msgerChat.scrollTop += 500;
-  }
+}
 
 function appendMessageError(name, img, side, text) {
 	//   Simple solution for small apps


### PR DESCRIPTION
Potential fix for [https://github.com/innovationcore/SmartState-public/security/code-scanning/4](https://github.com/innovationcore/SmartState-public/security/code-scanning/4)

To eliminate the DOM text reinterpreted as HTML vulnerability, we must ensure user-provided text (from `msgerInput.value`, passed as `text` to `appendMessage`) is safely encoded before being rendered as HTML. The best approach is to encode/escape meta-characters so they can't be interpreted as HTML—specifically, replacing `<`, `>`, `&`, `"`, and `'` with their respective HTML entities.

The fix is to add a dedicated "escapeHTML" function that safely escapes the text, then use it on `text` in the construction of the HTML string in `appendMessage`.  
- Only the `appendMessage` function and places that use `${text}` for user-controlled text need modification in `website/SmartState-frontend/js/chat.js`.
- Insert the "escapeHTML" function above `appendMessage`.
- Change the template literal to use `escapeHTML(text)` rather than raw `${text}`.

No third-party package is strictly necessary, but for simplicity, we'll write a basic escapeHTML function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
